### PR TITLE
doc: Fix blog.html -> section.html in documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,7 +160,7 @@ The section `blog` is the most standard section. It show a list of article with 
 To use the blog template, configure the section with the following front matter:
 
 ```toml
-template = "blog.html"
+template = "section.html"
 page_template = "blog-page.html"
 ```
 

--- a/content/blog/how-to-use.md
+++ b/content/blog/how-to-use.md
@@ -169,7 +169,7 @@ The section `blog` is the most standard section. It show a list of article with 
 To use the blog template, configure the section with the following front matter:
 
 ```toml
-template = "blog.html"
+template = "section.html"
 page_template = "blog-page.html"
 ```
 


### PR DESCRIPTION
In b9becf0, blog.html was renamed section.html. The documentation has not been updated with this change.