### PR TITLE
Port to Zola 0.23

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,5 +259,6 @@ To use this block, you can just create a new template name `templates/base.html`
 
 ## Icons
 
-The icons available in this project are stored in a dedicated macro function in `templates/macros/icons.html`.
-To add a new svg, you can add a case in the `if elif .. else` of the function containing the svg copied from [heroicons](https://heroicons.com/) for instance.
+The icons available in this project are stored in a dedicated component in `templates/macros/icons.html`.
+To add a new SVG, you must implement a component called `icons.extras` with a similar structure, that acts as a fallback.
+Additional SVGs can be copied from [heroicons](https://heroicons.com/), for instance.

--- a/config.toml
+++ b/config.toml
@@ -27,11 +27,10 @@ paths = "on"
 taxonomies = "on"
 anchors = "on"
 
-[markdown]
+[markdown.highlighting]
 # Whether to do syntax highlighting
-# Theme can be customised by setting the `highlight_theme` variable to a theme supported by Zola
-highlight_code = true
-highlight_theme = "base16-ocean-dark"
+# Theme can be customised by setting the `theme` variable to a theme supported by Zola
+theme = "one-dark-pro"
 
 [extra]
 version = "1.0.1"

--- a/content/blog/how-to-use.md
+++ b/content/blog/how-to-use.md
@@ -242,5 +242,7 @@ url_slides = "path_to_slides"
 
 ## Icons
 
-The icons available in this project are stored in a dedicated macro function in `templates/macros/icons.html`.
-To add a new svg, you can add a case in the `if elif .. else` of the function containing the svg copied from [heroicons](https://heroicons.com/) for instance.
+The icons available in this project are stored in a dedicated component in `templates/macros/icons.html`.
+To add a new SVG, you must implement a component called `icons.extras` with a similar structure, that acts as a fallback.
+Additional SVGs can be copied from [heroicons](https://heroicons.com/), for instance.
+

--- a/templates/404.html
+++ b/templates/404.html
@@ -1,7 +1,7 @@
 {% extends "base.html" %}
 {% block head -%}
 <meta charset="utf-8">
-{{ macros_head::stylesheet() }}
+{{<head.stylesheet/>}}
 {% block css -%}
 {% endblock css -%}
 <title>404 Page not found</title>

--- a/templates/base.html
+++ b/templates/base.html
@@ -1,10 +1,3 @@
-{% import 'macros/head.html' as macros_head -%}
-{% import 'macros/nav.html' as macros_nav -%}
-{% import 'macros/macros.html' as macros -%}
-{% import 'macros/icons.html' as icons -%}
-{% import 'macros/blog.html' as blog -%}
-{% import 'macros/publication.html' as publication -%}
-
 <!DOCTYPE html>
 <html lang="{{ lang | default(value=config.default_language)}}">
 
@@ -25,11 +18,10 @@
 
   {% block head -%}
     {% block css -%}
-      {{ macros_head::stylesheet() }}
+      {{<head.stylesheet/>}}
     {% endblock css -%}
 
     {% block title -%}
-      {% set section = load_data(path=current_path ~ "_index.md", metadata_only=true, required = false)  -%}
     {% endblock title -%}
   {% endblock head -%}
 </head>
@@ -37,7 +29,7 @@
 <body class="bg-white">
   <!-- Top nav bar -->
   {% block nav -%}
-    {{ macros_nav::nav(website_title=config.title) }}
+  {{<nav.navigation config={config} section={section | default(value=none)} page={page | default(value=none)} current_path={current_path | default(value=none)} lang={lang} website_title={config.title}/>}}
   {% endblock nav -%}
   <!-- Container -->
   {% block content -%}

--- a/templates/blog-page.html
+++ b/templates/blog-page.html
@@ -16,7 +16,7 @@
   <p class="pb-4 text-gray-600"> <span class="font-bold">TLDR.</span> {{ page.extra.tldr | safe }} </p>
   {% endif -%}
   <article class="prose prose-indigo max-w-3xl">
-    {{ macros::toc() }}
+    {{<macros.toc page={page} lang={lang}/>}}
     {{ page.content | safe }}
     {% if page.extra.external_link %}<p><a href="{{page.extra.external_link | safe}}" target="_blank">{{page.extra.external_link | safe}}</a></p>{% endif -%}
   </article>

--- a/templates/contact-page.html
+++ b/templates/contact-page.html
@@ -3,6 +3,6 @@
 {% block content %}
 <div class="container max-w-3xl mx-auto px-3">
   <div class="mb-8"></div>
-  {{ macros::contact_from_config(section=section, config=config) }}
+  {{<macros.contact_from_config config={config} lang={lang}/>}}
 </div>
 {% endblock content %}

--- a/templates/index.html
+++ b/templates/index.html
@@ -16,7 +16,7 @@
         <div class="flex flex-row flex-wrap container py-10 justify-center">
           {% for icon in section.extra.avatar_icons %}
             <div class="basis p-3 ">
-              <a href="{{icon.link}}" target="_blank"><i>{{ icons::factory(icon=icon.icon,classes="inline h-12 w-12 flex-no-shrink stroke-blue-600 hover:stroke-blue-800 visited:stroke-purple-600 fill-blue-600 visited:fill-purple-600 hover:fill-blue-800 ") }}</i></a>
+              <a href="{{icon.link}}" target="_blank"><i>{{<icons.factory icon={icon.icon} classes="inline h-12 w-12 flex-no-shrink stroke-blue-600 hover:stroke-blue-800 visited:stroke-purple-600 fill-blue-600 visited:fill-purple-600 hover:fill-blue-800 "/>}}</i></a>
             </div>
           {% endfor %}
         </div>
@@ -43,7 +43,7 @@
             <li class="py-1">
               <div class="flex flex-row flex-wrap">
                 <div class="basis-full">
-                  <i>{{ icons::factory(icon="academic",classes="inline h-6 w-6 flex-no-shrink") }}</i> {{ course.course }}, {{ course.year }}
+                  <i>{{<icons.factory icon="academic" classes="inline h-6 w-6 flex-no-shrink"/>}}</i> {{ course.course }}, {{ course.year }}
                 </div>
                 <div class="basis-full text-gray-400">
                 {{ course.institution }}
@@ -68,7 +68,7 @@
         <div class="container max-w-4xl mx-auto px-4 py-8">
           {% set index_elements = ssection_data.extra.index_elements | default(value=2) -%}
           {% set show_description = ssection_data.extra.description_in_index | default(value=true) -%}
-          {{ macros::section_index_summary(section_path=ssection, show_element=index_elements, show_description=show_description) }}
+          {{<macros.section_index_summary config={config} section_path={ssection} lang={lang} show_element={index_elements} show_description={show_description}/>}}
         </div>
       </div>
     {% set_global index = index + 1 -%}
@@ -87,7 +87,7 @@
     {% if config.extra.contact_in_index == true -%}
     <div class="{% if index % 2 != 0%} bg-white {% else %} bg-gray-50 {% endif %}">
       <div class="container max-w-4xl mx-auto px-4">
-      {{ macros::contact_from_config(section=section, config=config) }}
+        {{<macros.contact_from_config config={config} lang={lang}/>}}
       </div>
     </div>
     {% endif -%}

--- a/templates/macros/blog.html
+++ b/templates/macros/blog.html
@@ -1,6 +1,6 @@
-{% macro page_summary(page, show_wordcount=false, show_description=true) %}
+{% component blog.page_summary(config, page, lang: string, show_wordcount: bool = false, show_description: bool = true) %}
 {% if page.extra.type -%} {# is this publication? -#}
-{{ publication::summary(page=page, show_urls=false, show_frame=false, show_description=show_description) }}
+{{<publication.summary config={config} page={page} lang={lang} show_urls={false} show_frame={false} show_description={show_description}/>}}
 {% else -%}
 {% if page.extra.external_link -%}
 <a href="{{ page.extra.external_link | safe }}" target="_blank">
@@ -18,4 +18,4 @@
   <p class="text-sm text-slate-400"> {{ page.date }} {% if show_wordcount == true -%} • wordcount: {{ page.word_count }} • {{ page.reading_time }} min read {% endif -%}</p>
 </a>
 {% endif -%}
-{% endmacros %}
+{% endcomponent blog.page_summary %}

--- a/templates/macros/contact.html
+++ b/templates/macros/contact.html
@@ -1,5 +1,4 @@
-
-{% macro contact_list(title, links="", email="") %}
+{% component contact.list(title: string, links: array = [], email: string = "") %}
 <div class="flex sm:flex-row flex-col py-4">
   <div class="sm:basis-2/5 grow pb-4 sm:pb-0">
     <div class="prose">
@@ -10,15 +9,15 @@
     <ul>
       {% if email -%}
       <li class="font-bold text-lg pb-4 text-blue-600 hover:text-blue-800 visited:text-purple-600 flex-row flex-nowrap flex">
-      <i>{{ icons::factory(icon="mail",classes="inline h-6 w-6 flex-no-shrink") }}</i>
+        <i>{{<icons.factory icon="mail" classes="inline h-6 w-6 flex-no-shrink"/>}}</i>
       <a href="mailto:{{ email }}"> {{ email }} </a></li>
       {% endif -%}
       {% for link in links -%}
       <li class="font-bold text-lg pb-4 text-blue-600 hover:text-blue-800 visited:text-purple-600">
-        {% if link.icon -%}<i>{{ icons::factory(icon=link.icon,classes="inline h-6 w-6 flex-no-shrink") }}</i>{% endif -%}
+        {% if link.icon -%}<i>{{<icons.factory icon={link.icon} classes="inline h-6 w-6 flex-no-shrink"/>}}</i>{% endif -%}
         <a target="_blank" href="{{ link.link }}"> {{ link.name }} </a></li>
       {% endfor -%}
     </ul>
   </div>
 </div>
-{% endmacro %}
+{% endcomponent contact.list %}

--- a/templates/macros/head.html
+++ b/templates/macros/head.html
@@ -1,5 +1,4 @@
-
-{% macro stylesheet() %}
+{% component head.stylesheet() %}
 <!-- CSS -->
 <link rel="stylesheet" href="{{ get_url(path="styles/styles.css") | safe }}" />
-{% endmacro %}
+{% endcomponent head.stylesheet %}

--- a/templates/macros/icons.html
+++ b/templates/macros/icons.html
@@ -1,4 +1,7 @@
-{% macro factory(icon, classes="") %}
+{% component icons.extras(icon: string, classes: string = "") %}
+{% endcomponent icons.extras %}
+
+{% component icons.factory(icon: string, classes: string = "") %}
 
 {% if icon == "academic" -%}
 <svg xmlns="http://www.w3.org/2000/svg" class="{{ classes }}" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
@@ -30,4 +33,4 @@
 </svg>
 {% endif -%}
 
-{% endmacro %}
+{% endcomponent icons.factory %}

--- a/templates/macros/icons.html
+++ b/templates/macros/icons.html
@@ -28,9 +28,14 @@
 {% elif icon == "goodreads" -%}
 <svg role="img" class="{{ classes }}" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg"><title>Goodreads</title><path d="M11.43 23.995c-3.608-.208-6.274-2.077-6.448-5.078.695.007 1.375-.013 2.07-.006.224 1.342 1.065 2.43 2.683 3.026 1.583.496 3.737.46 5.082-.174 1.351-.636 2.145-1.822 2.503-3.577.212-1.042.236-1.734.231-2.92l-.005-1.631h-.059c-1.245 2.564-3.315 3.53-5.59 3.475-5.74-.054-7.68-4.534-7.528-8.606.01-5.241 3.22-8.537 7.557-8.495 2.354-.14 4.605 1.362 5.554 3.37l.059.002.002-2.918 2.099.004-.002 15.717c-.193 7.04-4.376 7.89-8.209 7.811zm6.1-15.633c-.096-3.26-1.601-6.62-5.503-6.645-3.954-.017-5.625 3.592-5.604 6.85-.013 3.439 1.643 6.305 4.703 6.762 4.532.591 6.551-3.411 6.404-6.967z"/></svg>
 {% else -%}
-<svg xmlns="http://www.w3.org/2000/svg" class="{{ classes }}" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
-  <path stroke-linecap="round" stroke-linejoin="round" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" />
-</svg>
+  {% set custom = <icons.extras icon={icon} classes={classes}/> -%}
+  {% if custom -%}
+    {{ custom }}
+  {% else -%}
+    <svg xmlns="http://www.w3.org/2000/svg" class="{{ classes }}" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+      <path stroke-linecap="round" stroke-linejoin="round" d="M18.364 18.364A9 9 0 005.636 5.636m12.728 12.728A9 9 0 015.636 5.636m12.728 12.728L5.636 5.636" />
+    </svg>
+  {% endif -%}
 {% endif -%}
 
 {% endcomponent icons.factory %}

--- a/templates/macros/macros.html
+++ b/templates/macros/macros.html
@@ -1,11 +1,8 @@
-{% import 'macros/contact.html' as macros_contact -%}
-{% import 'macros/blog.html' as macros_blog -%}
-
-{% macro dot_lang() -%}
+{% component macros.dot_lang(config, lang: string) -%}
   {% if lang == config.default_language -%}{{ "" }}{% else -%}{{ "." ~ lang }}{% endif -%}
-{% endmacro %}
+{% endcomponent macros.dot_lang %}
 
-{% macro toc() -%}
+{% component macros.toc(page, lang: string) -%}
 {% if page.toc and page.extra.toc -%}
 <div class="bg-gray-50 px-4 pb-1">
 <h2>{{trans(key="toc", lang=lang)}}</h2>
@@ -25,27 +22,26 @@
 </ul>
 </div>
 {% endif -%}
-{% endmacro %}
+{% endcomponent macros.toc %}
 
-{% macro contact_from_config(section, config) -%}
+{% component macros.contact_from_config(config, lang: string) -%}
   {% set email = "" -%}
   {% if config.extra.email -%}
     {% set email = config.extra.email -%}
   {% endif -%}
 
-  {% set dot_lang = macros::dot_lang() -%}
+  {% set dot_lang = <macros.dot_lang config={config} lang={lang}/> -%}
   {% set contact = get_page(path="./contacts" ~dot_lang~ ".md", metadata_only=true) -%}
 
-  {% set links = "" -%}
+  {% set links = [] -%}
   {% if contact.extra.links -%}
     {% set links = contact.extra.links -%}
   {% endif -%}
   <a name="contacts"></a>
-  {{ macros_contact::contact_list(title=contact.title, links=links, email=email) }}
-  </div>
-{% endmacro %}
+  {{<contact.list title={contact.title} links={links} email={email}/>}}
+{% endcomponent macros.contact_from_config %}
 
-{% macro section_index_summary(section_path, show_wordcount=false, show_element=2, show_description=true) %}
+{% component macros.section_index_summary(config, section_path: string, lang: string, show_wordcount: bool = false, show_element: integer = 2, show_description: bool = true) %}
   {% set section = get_section(path=section_path) -%}
   {% set title = section.extra.index_title | default(value=section.title) -%}
   <div class="flex sm:flex-row flex-col py-4">
@@ -57,13 +53,13 @@
     </div>
     <div class="sm:basis-3/5 grow">
       <ul>
-        {% for page in section.pages | slice(end=show_element) -%}
+        {% for page in section.pages[:show_element] -%}
           <li class="pb-3">
-              {{ blog::page_summary(page=page, show_wordcount=show_wordcount, show_description=show_description) }}
+            {{<blog.page_summary config={config} page={page} lang={lang} show_wordcount={show_wordcount} show_description={show_description}/>}}
           </li>
         {% endfor %}
         <li><a href="{{section.permalink | safe}}" class="text-blue-600 hover:text-blue-800">...</a></li>
       </ul>
     </div>
   </div>
-{% endmacro %}
+{% endcomponent macros.section_index_summary %}

--- a/templates/macros/nav.html
+++ b/templates/macros/nav.html
@@ -1,13 +1,13 @@
-{% macro nav(website_title) %}
+{% component nav.navigation(config, section, page, current_path, lang: string, website_title: string) %}
 <nav id="header" class="w-full z-10 top-0 shadow-md mx-0">
   <div id="progress" class="top-0"></div>
   <!-- <div class="w-full max-w-5xl mx-auto flex flex-wrap items-center justify-between mt-0 py-2  sm:bg-green-900 md:bg-red-900 lg:bg-blue-900 bg-yellow-900"> -->
   <div class="w-full max-w-4xl mx-auto flex sm:flex-nowrap flex-wrap items-center justify-between mt-0 py-2">
     <div class="pl-4">
-      {%set lang_base="" -%}
-      {%if lang != config.default_language-%}
-        {%set lang_base=lang%}
-      {%endif-%}
+      {% set lang_base = "" -%}
+      {% if lang != config.default_language -%}
+        {% set lang_base = lang %}
+      {% endif -%}
       <a class="text-gray-900 text-base no-underline hover:no-underline font-extrabold" href="{{config.base_url}}/{{lang_base}}">
         {{ website_title }}
       </a>
@@ -16,13 +16,13 @@
     <div class="w-full grow sm:flex sm:items-center flex-wrap sm:flex-nowrap sm:w-auto mt-2 sm:mt-0 bg-transparent z-20" id="nav-content">
       <ul class="list-reset flex flex-wrap sm:justify-end flex-1 items-center">
           {# Get the upper section -#}
-          {% set dot_lang = macros::dot_lang() -%}
+          {% set dot_lang = <macros.dot_lang config={config} lang={lang}/> -%}
           {% set index_section = get_section(path="_index"~dot_lang~".md", metadata_only=true) -%}
           {% for ssection in index_section.subsections -%}
             {% set ssection_data = get_section(path=ssection, metadata_only=true) -%}
             {% if not ssection_data.extra.hidden_nav -%}
             <li class="mr-3 text-sm">
-              <a href="{{ get_url(path=ssection_data.path, trailing_slash=false) }}" class={%if current_path and current_path is starting_with(ssection_data.path) %}"inline-block py-2 px-4 text-sky-600 font-bold no-underline"{% else %}"inline-block text-gray-600 no-underline hover:text-gray-900 hover:text-underline py-2 px-4"{%endif%}>
+              <a href="{{ get_url(path=ssection_data.path, trailing_slash=false) }}" class={%if current_path and current_path is starting_with(pat=ssection_data.path) %}"inline-block py-2 px-4 text-sky-600 font-bold no-underline"{% else %}"inline-block text-gray-600 no-underline hover:text-gray-900 hover:text-underline py-2 px-4"{%endif%}>
                 {{ssection_data.title}}
               </a>
             </li>
@@ -36,19 +36,19 @@
 
           {% for item in menu_items -%}
           <li class="mr-3 text-sm">
-            <a href={{ get_url(path=item.path, trailing_slash=false, lang=lang) }} class={%if current_path and current_path is starting_with(item.path) %}"inline-block py-2 px-4 text-sky-600 font-bold no-underline"{% else %}"inline-block text-gray-600 no-underline hover:text-gray-900 hover:text-underline py-2 px-4"{%endif%}>
+            <a href={{ get_url(path=item.path, trailing_slash=false, lang=lang) }} class={%if current_path and current_path is starting_with(pat=item.path) %}"inline-block py-2 px-4 text-sky-600 font-bold no-underline"{% else %}"inline-block text-gray-600 no-underline hover:text-gray-900 hover:text-underline py-2 px-4"{%endif%}>
               {{item.name}}
             </a>
           </li>
           {% endfor -%}
 
           {#Get the translations for this section if any-#}
-          {% set translations = section.translations | default(value=page.translations|default(value=[])) -%}
+          {% set translations = section?.translations | default(value=page?.translations | default(value=[])) -%}
 
           {%set langs = config.extra.language_codes | default(value=[]) -%}
           {%for trans_code in langs -%}
             {#Find if a translation exist for this section -#}
-            {% set other_lang = translations | filter(attribute="lang", value=trans_code) | first -%}
+            {% set other_lang = [t for t in translations if t.lang == trans_code] | first -%}
 
             {#
               Now the objective of this if/elif/if is to ensure that we have a link to other languages at the end of the navbar
@@ -76,4 +76,4 @@
     </div>
   </div>
 </nav>
-{% endmacro %}
+{% endcomponent nav.navigation %}

--- a/templates/macros/publication.html
+++ b/templates/macros/publication.html
@@ -1,21 +1,21 @@
-{% macro bibpath(page) -%}
+{% component publication.bibpath(page) -%}
 {% for asset in page.assets -%}
-  {% if asset is ending_with("bib") -%}{{asset}}{% break -%}{% endif -%}
+  {% if asset is ending_with(pat="bib") -%}{{asset}}{% break -%}{% endif -%}
 {% endfor -%}
-{% endmacro -%}
+{% endcomponent publication.bibpath %}
 
-{% macro title(page, bibtags) -%}
+{% component publication.title(page, bibtags) -%}
   {% set bibtitle = bibtags.title | default(value="") -%}
   {{page.title | default(value=bibtitle)}}
-{% endmacro -%}
+{% endcomponent publication.title -%}
 
-{% macro authors(page, bibtags, links_allowed=true) -%}
+{% component publication.authors(page, bibtags, links_allowed: bool = true) -%}
   {% if page.taxonomies.authors -%}
     {% for author in page.taxonomies.authors -%}
       {% if not loop.first %}, {% endif -%}
-      {% if links_allowed-%}<a href="{{ get_taxonomy_url(kind="authors", name=author, lang=page.lang) }}">{%endif-%}
+      {% if links_allowed -%}<a href="{{ get_taxonomy_url(kind="authors", name=author, lang=page.lang) }}">{%endif-%}
       {{ author -}}
-      {% if links_allowed-%}</a>{%endif-%}
+      {% if links_allowed -%}</a>{%endif-%}
     {% endfor %}
     {# page.taxonomies.authors | join(sep=", ") #}
   {% elif page.extra.authors -%}
@@ -25,17 +25,17 @@
   {% else -%}
     Unknown author. Refer to the documentation.
   {% endif -%}
-{% endmacro -%}
+{% endcomponent publication.authors -%}
 
-{% macro abstract(page, bibtags) -%}
+{% component publication.abstract(page, bibtags) -%}
   {% if page.extra.abstract -%}
     {{ page.extra.abstract | markdown(inline=true) | safe }}
   {% elif bibtags.abstract -%}
     {{ bibtags.abstract }}
   {% endif -%}
-{% endmacro -%}
+{% endcomponent publication.abstract -%}
 
-{% macro details(page, bibtags, sep=", ", links_allowed=true) -%}{#" • "#}
+{% component publication.details(page, bibtags, lang: string, sep: string = ", ", links_allowed: bool = true) -%}{#" • "#}
   {% if page.extra.publication  -%}
     {% if page.extra.publication is string -%}
       {{page.extra.publication | replace(from=", ", to=sep) -}}
@@ -50,16 +50,16 @@
     {% if bibtags.pages -%}{{ trans(key="pages", lang=lang) }} {{ bibtags.pages | replace(from="--", to="&ndash;") | safe }}{{ sep }}{% endif -%}
     {{ page.date | date(format="%B %Y") -}}
     {% if bibtags.doi -%}{{ sep -}}
-      {% if links_allowed-%}<a href="https://doi.org/{{bibtags.doi}}" target="_blank">{%endif-%}
+      {% if links_allowed -%}<a href="https://doi.org/{{bibtags.doi}}" target="_blank">{%endif-%}
       doi: {{ bibtags.doi -}}
-      {% if links_allowed-%}</a>{%endif-%}
+      {% if links_allowed -%}</a>{%endif-%}
     {% endif -%}
   {% endif -%}
-{% endmacro -%}
+{% endcomponent publication.details -%}
 
-{% macro summary(page, show_urls=true, show_frame=true, show_description=true) -%}
+{% component publication.summary(config, page, lang: string, show_urls: bool = true, show_frame: bool = true, show_description: bool = true) -%}
 {% set bibdata = "" -%}
-{% set bibtex_path = publication::bibpath(page=page) -%}
+{% set bibtex_path = <publication.bibpath page={page}/> -%}
 {% if bibtex_path -%}
 {% set bibtex = load_data(path=bibtex_path, required=false, format="bibtex") -%}
 {% if bibtex -%}{% set bibdata = bibtex.bibliographies[0].tags -%}{% endif -%}
@@ -75,9 +75,9 @@
 <div class="py-4 px-8 bg-white shadow-lg rounded-lg hover:shadow-xl">
 {% endif -%}
   <a href="{{ page.permalink | safe }}">
-    <p class="text-sm text-slate-400">{{publication::authors(page=page, bibtags=bibdata, links_allowed=false)}}</p>
-    <h2 class="text-xl font-bold text-blue-600 hover:text-blue-800 visited:text-purple-600">{{publication::title(page=page, bibtags=bibdata)}}</h2>
-    <p class="text-sm text-slate-400">{{publication::details(page=page, bibtags=bibdata, links_allowed=false)}}</p>
+    <p class="text-sm text-slate-400">{{<publication.authors page={page} bibtags={bibdata} links_allowed={false}/>}}</p>
+    <h2 class="text-xl font-bold text-blue-600 hover:text-blue-800 visited:text-purple-600">{{<publication.title page={page} bibtags={bibdata}/>}}</h2>
+    <p class="text-sm text-slate-400">{{<publication.details page={page} bibtags={bibdata} lang={lang} links_allowed={false}/>}}</p>
 
     {% if show_description and page.description -%}
     <p class="text-sm py-1"> {{ page.description | markdown(inline=true) | safe }} </p>
@@ -105,4 +105,4 @@
 {% if show_frame -%}
 </div>
 {% endif -%}
-{% endmacros %}
+{% endcomponent publication.summary %}

--- a/templates/page.html
+++ b/templates/page.html
@@ -8,7 +8,7 @@
   <div class="mb-8"></div>
 
   <article class="prose prose-indigo max-w-3xl">
-    {{ macros::toc() }}
+    {{<macros.toc page={page} lang={lang}/>}}
     {{ page.content | safe }}
     {% if page.extra.external_link %}<p><a href="{{page.extra.external_link | safe}}" target="_blank">{{page.extra.external_link | safe}}</a></p>{% endif -%}
   </article>

--- a/templates/publication-page.html
+++ b/templates/publication-page.html
@@ -7,7 +7,7 @@
 
 {% block content %}
 
-{% set bibtex_path = publication::bibpath(page=page) -%}
+{% set bibtex_path = <publication.bibpath page={page}/> -%}
 {% set bibdata = "" -%}
 {% if bibtex_path -%}
 {% set plaintex = load_data(path=bibtex_path, required=false, format="plain") -%}
@@ -19,14 +19,14 @@
 
 <div class="container max-w-3xl mx-auto px-4">
   <div class="pt-8 flex-col mb-8">
-    <h1 class="grow font-bold font-sans break-normal text-gray-900 text-3xl">{{publication::title(page=page, bibtags=bibdata)}}</h1>
+    <h1 class="grow font-bold font-sans break-normal text-gray-900 text-3xl">{{<publication.title page={page} bibtags={bibdata}/>}}</h1>
     <div class="grow">
-      <p class="text-sm text-slate-400">{{publication::authors(page=page, bibtags=bibdata)}}</p>
+      <p class="text-sm text-slate-400">{{<publication.authors page={page} bibtags={bibdata}/>}}</p>
     </div>
     <div class="grow">
-      <p class="text-sm text-slate-400">{{publication::details(page=page, bibtags=bibdata)}}</p>
+      <p class="text-sm text-slate-400">{{<publication.details page={page} bibtags={bibdata} lang={lang}/>}}</p>
     </div>
-    <div class="grow pt-2"> 
+    <div class="grow pt-2">
       {% if page.extra.url_pdf %}
       <a class="rounded-md border-solid border border-blue-600 inline-flex items-center text-blue-600 justify-center px-2 py-1 mr-2 text-xs font-bold" target="_blank" href="{{ page.extra.url_pdf }}"> pdf </a>
       {% elif page.extra.pdf %}
@@ -51,7 +51,7 @@
     {{ page.description | markdown(inline=true) | safe }}
   </article>
   {% endif -%}
-  {% set abstract = publication::abstract(page=page, bibtags=bibdata) -%}
+  {% set abstract = <publication.abstract page={page} bibtags={bibdata}/> -%}
   {% if abstract -%}
   <p class="font-bold">{{trans(key="Abstract", lang=lang)}}</p>
   <article class="prose prose-indigo max-w-3xl pb-4">{{abstract | safe}}</article>

--- a/templates/publications.html
+++ b/templates/publications.html
@@ -19,7 +19,7 @@
     {% for page in section.pages  -%}
       {% if page.extra.type == publication_type.type -%}
       <li class="pb-3">
-        {{ publication::summary(page=page) }}
+        {{<publication.summary config={config} page={page} lang={lang}/>}}
       </li>
       {% endif  -%}
     {% endfor -%}

--- a/templates/section.html
+++ b/templates/section.html
@@ -10,7 +10,7 @@
   <ul>
   {% for page in section.pages %}
     <li class="pb-3">
-      {{ blog::page_summary(page=page) }}
+      {{<blog.page_summary config={config} page={page} lang={lang}/>}}
     </li>
   {% endfor %}
   </ul>

--- a/templates/taxonomy_single.html
+++ b/templates/taxonomy_single.html
@@ -10,7 +10,7 @@
   <ul>
   {% for page in term.pages %}
     <li class="pb-3">
-        {{ blog::page_summary(page=page) }}
+      {{<blog.page_summary config={config} page={page} lang={lang}/>}}
     </li>
   {% endfor %}
   </ul>

--- a/theme.toml
+++ b/theme.toml
@@ -3,7 +3,7 @@ description = "Theme insipired by wowchemy academic."
 license = "MIT"
 homepage = "https://github.com/adfaure/kodama-theme"
 # The minimum version of Zola required
-min_version = "0.15"
+min_version = "0.23"
 
 # An optional live demo URL
 demo = "https://adfaure.github.io/kodama-theme/"


### PR DESCRIPTION
Zola 0.23 is very breaking :( It pretty much completely removed the macro system in favor of "components". Some annoying things that seem to come with that
* Global variables do not make it into the components, e.g. `config` needs to be passed in.
* Extending a component seems to be a bit more involved, e.g. `icons::factory` was reworked to call an optional `icons.extras` to allow easy user extensions.

This ports the theme to the new setup. It seems to work for me, both on the example theme and on a separate website I use it on. Still left to do
* [x] Update README
* [x] Update documentation
* [ ] Test some more? I don't have multiple languages, so that part is not well tested at all.

Some potential "cleanup" to do:
* [ ] Rename `templates/macros` to `templates/components`.
* [ ] Rename `templates/macros/macros.html` to something different? Not sure what..
* [ ] Rename `config.toml` to `zola.toml` (preferred starting with this version).
* [ ] Maybe also rename all the `file.component_name` component names to `kodama.component_name` for nice namespace consistency.